### PR TITLE
feat(issue-8): AI & Smart Automation — Ollama streaming, Git diff summary, AI panel

### DIFF
--- a/pr8-issues.md
+++ b/pr8-issues.md
@@ -4,3 +4,4 @@
 [x] Nothing happened when I use Analyze code + Issue
 [x] 分析code一樣沒有結果，第一次選Codex會出現一個Error, 後來選Claude按下generate沒任何反饋，我的路徑跟issue id都有提供，且有Load code& issue顯示正確
 [x] 分析code還是沒有Outpu，把Log打開看一下執行過程
+[x] Log: codex "stdin is not a terminal", claude spawned but no output

--- a/pr8-issues.md
+++ b/pr8-issues.md
@@ -1,0 +1,1 @@
+[x] AI 要可以選模型 Claude CLI or Codex CLI

--- a/pr8-issues.md
+++ b/pr8-issues.md
@@ -1,3 +1,4 @@
 [x] AI 要可以選模型 Claude CLI or Codex CLI
 [x] 功能改成獲取某專案下某人(或多人)的tickets，並讓AI分析問題點並給出未來建議
 [x] 可以讓AI在特定目錄下根據程式碼和選擇的issue分析，並給出建議如何修改
+[x] Nothing happened when I use Analyze code + Issue

--- a/pr8-issues.md
+++ b/pr8-issues.md
@@ -1,1 +1,3 @@
 [x] AI 要可以選模型 Claude CLI or Codex CLI
+[x] 功能改成獲取某專案下某人(或多人)的tickets，並讓AI分析問題點並給出未來建議
+[x] 可以讓AI在特定目錄下根據程式碼和選擇的issue分析，並給出建議如何修改

--- a/pr8-issues.md
+++ b/pr8-issues.md
@@ -3,3 +3,4 @@
 [x] 可以讓AI在特定目錄下根據程式碼和選擇的issue分析，並給出建議如何修改
 [x] Nothing happened when I use Analyze code + Issue
 [x] 分析code一樣沒有結果，第一次選Codex會出現一個Error, 後來選Claude按下generate沒任何反饋，我的路徑跟issue id都有提供，且有Load code& issue顯示正確
+[x] 分析code還是沒有Outpu，把Log打開看一下執行過程

--- a/pr8-issues.md
+++ b/pr8-issues.md
@@ -2,3 +2,4 @@
 [x] 功能改成獲取某專案下某人(或多人)的tickets，並讓AI分析問題點並給出未來建議
 [x] 可以讓AI在特定目錄下根據程式碼和選擇的issue分析，並給出建議如何修改
 [x] Nothing happened when I use Analyze code + Issue
+[x] 分析code一樣沒有結果，第一次選Codex會出現一個Error, 後來選Claude按下generate沒任何反饋，我的路徑跟issue id都有提供，且有Load code& issue顯示正確

--- a/src/main/api/aiClient.js
+++ b/src/main/api/aiClient.js
@@ -33,14 +33,17 @@ function findBinary(backend) {
  *   bin          - executable path
  *   args         - argv array
  *   stdin        - string to write to stdin (undefined = leave stdin as pipe)
- *   stdinMode    - 'ignore' to set stdin to /dev/null (skip pipe entirely)
+ *   stdinMode    - 'ignore'  → /dev/null (closed fd)
+ *                  'inherit' → inherit parent's stdin fd (lets child see parent TTY)
  *   label        - human label for error messages
  *   filterStderr - if true, only call onError for stderr lines matching /error/i
  *                  if false, surface all non-empty stderr immediately
  *   onToken / onDone / onError - callbacks
  */
 function spawnStreaming({ bin, args, stdin, stdinMode, label, filterStderr, onToken, onDone, onError }) {
-  const stdioOpt = stdinMode === 'ignore' ? ['ignore', 'pipe', 'pipe'] : 'pipe';
+  const stdioOpt = stdinMode === 'ignore'  ? ['ignore',  'pipe', 'pipe']
+                 : stdinMode === 'inherit' ? ['inherit', 'pipe', 'pipe']
+                 : 'pipe';
   let proc;
   try {
     proc = spawn(bin, args, { env: ENV, stdio: stdioOpt });
@@ -49,7 +52,7 @@ function spawnStreaming({ bin, args, stdin, stdinMode, label, filterStderr, onTo
     return null;
   }
 
-  if (stdin !== undefined && stdinMode !== 'ignore') {
+  if (stdin !== undefined && stdinMode !== 'ignore' && stdinMode !== 'inherit') {
     try {
       proc.stdin.write(stdin);
       proc.stdin.end();
@@ -134,11 +137,12 @@ function generate(prompt, backend, model, onToken, onDone, onError) {
   }
 
   if (backend === 'codex') {
-    // Codex CLI requires stdin to be a TTY — set stdinMode:'ignore' (/dev/null)
-    // and pass the prompt as a positional arg with --full-auto for non-interactive mode.
+    // Codex CLI checks process.stdin.isTTY and refuses non-TTY stdin.
+    // 'inherit' passes the parent terminal's stdin fd so Codex sees a real TTY.
+    // The prompt is passed as a positional arg; --full-auto disables interactive prompts.
     return spawnStreaming({
       bin, args: ['--full-auto', prompt],
-      stdinMode: 'ignore',
+      stdinMode: 'inherit',
       label: 'Codex CLI',
       filterStderr: false,
       onToken, onDone, onError,

--- a/src/main/api/aiClient.js
+++ b/src/main/api/aiClient.js
@@ -1,28 +1,87 @@
 'use strict';
 
+const os = require('os');
+const path = require('path');
 const { spawn } = require('child_process');
 const fs = require('fs');
 
+const HOME = os.homedir();
 const PROBE_PATHS = {
   ollama: ['/usr/local/bin/ollama', '/opt/homebrew/bin/ollama'],
-  claude: ['/usr/local/bin/claude', '/opt/homebrew/bin/claude'],
-  codex:  ['/usr/local/bin/codex',  '/opt/homebrew/bin/codex'],
+  claude: [
+    '/usr/local/bin/claude',
+    '/opt/homebrew/bin/claude',
+    path.join(HOME, '.local', 'bin', 'claude'),
+    path.join(HOME, 'bin', 'claude'),
+    path.join(HOME, '.volta', 'bin', 'claude'),
+  ],
+  codex: [
+    '/usr/local/bin/codex',
+    '/opt/homebrew/bin/codex',
+    path.join(HOME, '.local', 'bin', 'codex'),
+    path.join(HOME, 'bin', 'codex'),
+    path.join(HOME, '.volta', 'bin', 'codex'),
+  ],
 };
+
+const PATH_ENTRIES = [
+  '/usr/local/bin',
+  '/opt/homebrew/bin',
+  path.join(HOME, '.local', 'bin'),
+  path.join(HOME, 'bin'),
+  path.join(HOME, '.volta', 'bin'),
+  ...(process.env.PATH || '').split(path.delimiter).filter(Boolean),
+];
 
 const ENV = {
   ...process.env,
-  PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH || ''}`,
+  PATH: [...new Set(PATH_ENTRIES)].join(path.delimiter),
 };
+
+function isExecutable(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findBinaryOnPath(binary) {
+  for (const dir of ENV.PATH.split(path.delimiter)) {
+    const candidate = path.join(dir, binary);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+function findBinaryInNvm(binary) {
+  const versionsDir = path.join(HOME, '.nvm', 'versions', 'node');
+  try {
+    const versions = fs.readdirSync(versionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+      .reverse();
+
+    for (const version of versions) {
+      const candidate = path.join(versionsDir, version, 'bin', binary);
+      if (isExecutable(candidate)) return candidate;
+    }
+  } catch {
+    // nvm not installed or not accessible
+  }
+  return null;
+}
 
 function findBinary(backend) {
   for (const p of (PROBE_PATHS[backend] || [])) {
-    try {
-      fs.accessSync(p, fs.constants.X_OK);
-      return p;
-    } catch {
-      // not at this path
-    }
+    if (isExecutable(p)) return p;
   }
+  const pathHit = findBinaryOnPath(backend);
+  if (pathHit) return pathHit;
+  const nvmHit = findBinaryInNvm(backend);
+  if (nvmHit) return nvmHit;
   return backend; // PATH fallback
 }
 
@@ -36,11 +95,11 @@ function findBinary(backend) {
  *   stdinMode    - 'ignore'  → /dev/null (closed fd)
  *                  'inherit' → inherit parent's stdin fd (lets child see parent TTY)
  *   label        - human label for error messages
- *   filterStderr - if true, only call onError for stderr lines matching /error/i
- *                  if false, surface all non-empty stderr immediately
+ *   stderrMode   - 'all' captures all stderr text for non-zero exits
+ *                  /regex/ captures matching stderr text for non-zero exits
  *   onToken / onDone / onError - callbacks
  */
-function spawnStreaming({ bin, args, stdin, stdinMode, label, filterStderr, onToken, onDone, onError }) {
+function spawnStreaming({ bin, args, stdin, stdinMode, label, stderrMode = 'all', onToken, onDone, onError }) {
   const stdioOpt = stdinMode === 'ignore'  ? ['ignore',  'pipe', 'pipe']
                  : stdinMode === 'inherit' ? ['inherit', 'pipe', 'pipe']
                  : 'pipe';
@@ -65,13 +124,17 @@ function spawnStreaming({ bin, args, stdin, stdinMode, label, filterStderr, onTo
   proc.stdout.on('data', (chunk) => onToken(chunk.toString()));
 
   let errorSent = false;
+  const stderrChunks = [];
   proc.stderr.on('data', (chunk) => {
-    const text = chunk.toString().trim();
-    if (!text) return;
-    if (filterStderr && !/error/i.test(text)) return;
-    if (!errorSent) {
-      errorSent = true;
-      onError(text);
+    const text = chunk.toString();
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    if (stderrMode === 'all') {
+      stderrChunks.push(trimmed);
+      return;
+    }
+    if (stderrMode instanceof RegExp && stderrMode.test(trimmed)) {
+      stderrChunks.push(trimmed);
     }
   });
 
@@ -79,8 +142,17 @@ function spawnStreaming({ bin, args, stdin, stdinMode, label, filterStderr, onTo
     if (code === null) return; // killed by cancel — no callback
     if (code === 0) {
       onDone();
-    } else if (!errorSent) {
-      onError(`${label} exited with code ${code}. Check that it is installed and authenticated.`);
+      return;
+    }
+
+    const stderrText = stderrChunks.join('\n').trim();
+    if (!errorSent) {
+      if (stderrText) {
+        onError(stderrText);
+      } else {
+        onError(`${label} exited with code ${code}. Check that it is installed and authenticated.`);
+      }
+      errorSent = true;
     }
   });
 
@@ -118,7 +190,7 @@ function generate(prompt, backend, model, onToken, onDone, onError) {
       bin, args: ['run', model || 'llama3.2', '--nowordwrap'],
       stdin: prompt,
       label: 'Ollama',
-      filterStderr: true, // Ollama emits loading progress to stderr; ignore non-errors
+      stderrMode: /error/i, // Ollama emits loading progress to stderr; ignore non-errors
       onToken, onDone, onError,
     });
   }
@@ -126,25 +198,21 @@ function generate(prompt, backend, model, onToken, onDone, onError) {
   if (backend === 'claude') {
     // `claude -p` reads the prompt from stdin in print/non-interactive mode.
     // Passing prompt as a positional arg after -p does not work with Claude Code CLI.
-    // This is slow (API call); the UI progress indicator shows it is working.
     return spawnStreaming({
       bin, args: ['-p'],
       stdin: prompt,
       label: 'Claude CLI',
-      filterStderr: false,
       onToken, onDone, onError,
     });
   }
 
   if (backend === 'codex') {
-    // Codex CLI checks process.stdin.isTTY and refuses non-TTY stdin.
-    // 'inherit' passes the parent terminal's stdin fd so Codex sees a real TTY.
-    // The prompt is passed as a positional arg; --full-auto disables interactive prompts.
+    // `codex exec` is the supported non-interactive mode. Passing the prompt
+    // as an argument avoids the TTY requirement that applies when reading stdin.
     return spawnStreaming({
-      bin, args: ['--full-auto', prompt],
-      stdinMode: 'inherit',
+      bin, args: ['exec', '--full-auto', prompt],
+      stdinMode: 'ignore',
       label: 'Codex CLI',
-      filterStderr: false,
       onToken, onDone, onError,
     });
   }

--- a/src/main/api/aiClient.js
+++ b/src/main/api/aiClient.js
@@ -121,23 +121,23 @@ function generate(prompt, backend, model, onToken, onDone, onError) {
   }
 
   if (backend === 'claude') {
-    // `claude -p "<prompt>"` — print/non-interactive mode.
-    // Passing via stdin causes claude to hang waiting for interactive input;
-    // passing as a CLI arg works for prompts up to ~200 KB (within ARG_MAX).
+    // `claude -p` reads the prompt from stdin in print/non-interactive mode.
+    // Passing prompt as a positional arg after -p does not work with Claude Code CLI.
+    // This is slow (API call); the UI progress indicator shows it is working.
     return spawnStreaming({
-      bin, args: ['-p', prompt],
+      bin, args: ['-p'],
+      stdin: prompt,
       label: 'Claude CLI',
-      filterStderr: false, // surface all stderr (auth errors, warnings, etc.)
+      filterStderr: false,
       onToken, onDone, onError,
     });
   }
 
   if (backend === 'codex') {
-    // Codex CLI checks process.stdin.isTTY and errors if stdin is a pipe.
-    // --full-auto disables interactive approval prompts; pass prompt as arg
-    // and set stdin to 'ignore' (mapped to /dev/null) to avoid the TTY check.
+    // Codex CLI requires stdin to be a TTY — set stdinMode:'ignore' (/dev/null)
+    // and pass the prompt as a positional arg with --full-auto for non-interactive mode.
     return spawnStreaming({
-      bin, args: ['--full-auto', '--quiet', prompt],
+      bin, args: ['--full-auto', prompt],
       stdinMode: 'ignore',
       label: 'Codex CLI',
       filterStderr: false,

--- a/src/main/api/aiClient.js
+++ b/src/main/api/aiClient.js
@@ -3,13 +3,19 @@
 const { spawn } = require('child_process');
 const fs = require('fs');
 
-const OLLAMA_PROBE_PATHS = [
-  '/usr/local/bin/ollama',
-  '/opt/homebrew/bin/ollama',
-];
+const PROBE_PATHS = {
+  ollama: ['/usr/local/bin/ollama', '/opt/homebrew/bin/ollama'],
+  claude: ['/usr/local/bin/claude', '/opt/homebrew/bin/claude'],
+  codex:  ['/usr/local/bin/codex',  '/opt/homebrew/bin/codex'],
+};
 
-function findOllama() {
-  for (const p of OLLAMA_PROBE_PATHS) {
+const ENV = {
+  ...process.env,
+  PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH || ''}`,
+};
+
+function findBinary(backend) {
+  for (const p of (PROBE_PATHS[backend] || [])) {
     try {
       fs.accessSync(p, fs.constants.X_OK);
       return p;
@@ -17,64 +23,86 @@ function findOllama() {
       // not at this path
     }
   }
-  // Fall back to PATH lookup
-  return 'ollama';
+  // Fall back to PATH lookup using the backend name itself
+  return backend;
 }
 
-/**
- * Spawn `ollama run <model>`, pipe the prompt, and stream output tokens.
- * Returns the child process so the caller can .kill() it to cancel.
- *
- * @param {string}   prompt   - Full prompt text to send to the model
- * @param {string}   model    - Ollama model name (e.g. 'llama3.2')
- * @param {function} onToken  - Called with each output string chunk
- * @param {function} onDone   - Called when the process exits cleanly
- * @param {function} onError  - Called with an error message string
- * @returns {ChildProcess|null}
- */
-function generate(prompt, model, onToken, onDone, onError) {
-  const ollamaPath = findOllama();
-
-  const env = {
-    ...process.env,
-    PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH || ''}`,
-  };
-
+function spawnStreaming({ bin, args, stdin, label, onToken, onDone, onError }) {
   let proc;
   try {
-    proc = spawn(ollamaPath, ['run', model, '--nowordwrap'], { env });
+    proc = spawn(bin, args, { env: ENV });
   } catch (err) {
-    onError('Failed to start Ollama: ' + err.message);
+    onError(`Failed to start ${label}: ${err.message}`);
     return null;
   }
 
-  proc.stdin.write(prompt + '\n');
-  proc.stdin.end();
+  if (stdin !== undefined) {
+    proc.stdin.write(stdin + '\n');
+    proc.stdin.end();
+  }
 
-  proc.stdout.on('data', (chunk) => {
-    onToken(chunk.toString());
-  });
+  proc.stdout.on('data', (chunk) => onToken(chunk.toString()));
 
   proc.stderr.on('data', (chunk) => {
     const text = chunk.toString().trim();
-    // Ollama prints model-loading progress to stderr — only surface real errors
-    if (/error/i.test(text)) onError(text);
+    if (text && /error/i.test(text)) onError(text);
   });
 
   proc.on('close', (code) => {
-    // code === null means killed (user cancel) — no callback needed
+    // null = killed by cancel, skip
     if (code === 0) onDone();
   });
 
   proc.on('error', (err) => {
     if (err.code === 'ENOENT') {
-      onError('Ollama not found. Install it from https://ollama.com and make sure it is running.');
+      onError(`${label} not found. Make sure it is installed and on your PATH.`);
     } else {
-      onError('Ollama process error: ' + err.message);
+      onError(`${label} error: ${err.message}`);
     }
   });
 
   return proc;
 }
 
-module.exports = { generate, findOllama };
+/**
+ * Generate a response using the selected backend.
+ *
+ * @param {string}   prompt   - Full prompt text
+ * @param {string}   backend  - 'ollama' | 'claude' | 'codex'
+ * @param {string}   model    - Model name (used for Ollama only)
+ * @param {function} onToken  - Called with each output chunk
+ * @param {function} onDone   - Called on clean exit
+ * @param {function} onError  - Called with error message string
+ * @returns {ChildProcess|null}
+ */
+function generate(prompt, backend, model, onToken, onDone, onError) {
+  const bin = findBinary(backend);
+
+  if (backend === 'ollama') {
+    return spawnStreaming({
+      bin, args: ['run', model || 'llama3.2', '--nowordwrap'],
+      stdin: prompt, label: 'Ollama', onToken, onDone, onError,
+    });
+  }
+
+  if (backend === 'claude') {
+    // claude -p "<prompt>" — print mode, outputs to stdout
+    return spawnStreaming({
+      bin, args: ['-p', prompt],
+      label: 'Claude CLI', onToken, onDone, onError,
+    });
+  }
+
+  if (backend === 'codex') {
+    // codex "<prompt>" — query mode
+    return spawnStreaming({
+      bin, args: [prompt],
+      label: 'Codex CLI', onToken, onDone, onError,
+    });
+  }
+
+  onError(`Unknown backend: ${backend}`);
+  return null;
+}
+
+module.exports = { generate, findBinary };

--- a/src/main/api/aiClient.js
+++ b/src/main/api/aiClient.js
@@ -23,11 +23,22 @@ function findBinary(backend) {
       // not at this path
     }
   }
-  // Fall back to PATH lookup using the backend name itself
-  return backend;
+  return backend; // PATH fallback
 }
 
-function spawnStreaming({ bin, args, stdin, label, onToken, onDone, onError }) {
+/**
+ * Spawn a subprocess and stream stdout tokens.
+ *
+ * @param {object} opts
+ *   bin          - executable path
+ *   args         - argv array
+ *   stdin        - string to write to stdin (undefined = leave stdin open)
+ *   label        - human label for error messages
+ *   filterStderr - if true, only call onError for stderr lines matching /error/i
+ *                  if false, surface all non-empty stderr immediately
+ *   onToken / onDone / onError - callbacks
+ */
+function spawnStreaming({ bin, args, stdin, label, filterStderr, onToken, onDone, onError }) {
   let proc;
   try {
     proc = spawn(bin, args, { env: ENV });
@@ -37,27 +48,45 @@ function spawnStreaming({ bin, args, stdin, label, onToken, onDone, onError }) {
   }
 
   if (stdin !== undefined) {
-    proc.stdin.write(stdin + '\n');
-    proc.stdin.end();
+    try {
+      proc.stdin.write(stdin);
+      proc.stdin.end();
+    } catch (err) {
+      onError(`Failed to write to ${label} stdin: ${err.message}`);
+      return null;
+    }
   }
 
   proc.stdout.on('data', (chunk) => onToken(chunk.toString()));
 
+  let errorSent = false;
   proc.stderr.on('data', (chunk) => {
     const text = chunk.toString().trim();
-    if (text && /error/i.test(text)) onError(text);
+    if (!text) return;
+    if (filterStderr && !/error/i.test(text)) return;
+    if (!errorSent) {
+      errorSent = true;
+      onError(text);
+    }
   });
 
   proc.on('close', (code) => {
-    // null = killed by cancel, skip
-    if (code === 0) onDone();
+    if (code === null) return; // killed by cancel — no callback
+    if (code === 0) {
+      onDone();
+    } else if (!errorSent) {
+      onError(`${label} exited with code ${code}. Check that it is installed and authenticated.`);
+    }
   });
 
   proc.on('error', (err) => {
-    if (err.code === 'ENOENT') {
-      onError(`${label} not found. Make sure it is installed and on your PATH.`);
-    } else {
-      onError(`${label} error: ${err.message}`);
+    if (!errorSent) {
+      errorSent = true;
+      if (err.code === 'ENOENT') {
+        onError(`${label} not found. Make sure it is installed and on your PATH.`);
+      } else {
+        onError(`${label} error: ${err.message}`);
+      }
     }
   });
 
@@ -69,35 +98,46 @@ function spawnStreaming({ bin, args, stdin, label, onToken, onDone, onError }) {
  *
  * @param {string}   prompt   - Full prompt text
  * @param {string}   backend  - 'ollama' | 'claude' | 'codex'
- * @param {string}   model    - Model name (used for Ollama only)
- * @param {function} onToken  - Called with each output chunk
- * @param {function} onDone   - Called on clean exit
- * @param {function} onError  - Called with error message string
+ * @param {string}   model    - Model name (Ollama only)
+ * @param {function} onToken
+ * @param {function} onDone
+ * @param {function} onError
  * @returns {ChildProcess|null}
  */
 function generate(prompt, backend, model, onToken, onDone, onError) {
   const bin = findBinary(backend);
 
   if (backend === 'ollama') {
+    // Ollama reads the prompt from stdin; model name is a positional arg
     return spawnStreaming({
       bin, args: ['run', model || 'llama3.2', '--nowordwrap'],
-      stdin: prompt, label: 'Ollama', onToken, onDone, onError,
+      stdin: prompt,
+      label: 'Ollama',
+      filterStderr: true, // Ollama emits loading progress to stderr; ignore non-errors
+      onToken, onDone, onError,
     });
   }
 
   if (backend === 'claude') {
-    // claude -p "<prompt>" — print mode, outputs to stdout
+    // `claude -p` reads the prompt from stdin in print/non-interactive mode.
+    // Passing large prompts as a CLI arg would hit ARG_MAX limits.
     return spawnStreaming({
-      bin, args: ['-p', prompt],
-      label: 'Claude CLI', onToken, onDone, onError,
+      bin, args: ['-p'],
+      stdin: prompt,
+      label: 'Claude CLI',
+      filterStderr: false, // surface all stderr (auth errors, warnings, etc.)
+      onToken, onDone, onError,
     });
   }
 
   if (backend === 'codex') {
-    // codex "<prompt>" — query mode
+    // Codex CLI reads prompt from stdin
     return spawnStreaming({
-      bin, args: [prompt],
-      label: 'Codex CLI', onToken, onDone, onError,
+      bin, args: [],
+      stdin: prompt,
+      label: 'Codex CLI',
+      filterStderr: false,
+      onToken, onDone, onError,
     });
   }
 

--- a/src/main/api/aiClient.js
+++ b/src/main/api/aiClient.js
@@ -32,22 +32,24 @@ function findBinary(backend) {
  * @param {object} opts
  *   bin          - executable path
  *   args         - argv array
- *   stdin        - string to write to stdin (undefined = leave stdin open)
+ *   stdin        - string to write to stdin (undefined = leave stdin as pipe)
+ *   stdinMode    - 'ignore' to set stdin to /dev/null (skip pipe entirely)
  *   label        - human label for error messages
  *   filterStderr - if true, only call onError for stderr lines matching /error/i
  *                  if false, surface all non-empty stderr immediately
  *   onToken / onDone / onError - callbacks
  */
-function spawnStreaming({ bin, args, stdin, label, filterStderr, onToken, onDone, onError }) {
+function spawnStreaming({ bin, args, stdin, stdinMode, label, filterStderr, onToken, onDone, onError }) {
+  const stdioOpt = stdinMode === 'ignore' ? ['ignore', 'pipe', 'pipe'] : 'pipe';
   let proc;
   try {
-    proc = spawn(bin, args, { env: ENV });
+    proc = spawn(bin, args, { env: ENV, stdio: stdioOpt });
   } catch (err) {
     onError(`Failed to start ${label}: ${err.message}`);
     return null;
   }
 
-  if (stdin !== undefined) {
+  if (stdin !== undefined && stdinMode !== 'ignore') {
     try {
       proc.stdin.write(stdin);
       proc.stdin.end();
@@ -119,11 +121,11 @@ function generate(prompt, backend, model, onToken, onDone, onError) {
   }
 
   if (backend === 'claude') {
-    // `claude -p` reads the prompt from stdin in print/non-interactive mode.
-    // Passing large prompts as a CLI arg would hit ARG_MAX limits.
+    // `claude -p "<prompt>"` — print/non-interactive mode.
+    // Passing via stdin causes claude to hang waiting for interactive input;
+    // passing as a CLI arg works for prompts up to ~200 KB (within ARG_MAX).
     return spawnStreaming({
-      bin, args: ['-p'],
-      stdin: prompt,
+      bin, args: ['-p', prompt],
       label: 'Claude CLI',
       filterStderr: false, // surface all stderr (auth errors, warnings, etc.)
       onToken, onDone, onError,
@@ -131,10 +133,12 @@ function generate(prompt, backend, model, onToken, onDone, onError) {
   }
 
   if (backend === 'codex') {
-    // Codex CLI reads prompt from stdin
+    // Codex CLI checks process.stdin.isTTY and errors if stdin is a pipe.
+    // --full-auto disables interactive approval prompts; pass prompt as arg
+    // and set stdin to 'ignore' (mapped to /dev/null) to avoid the TTY check.
     return spawnStreaming({
-      bin, args: [],
-      stdin: prompt,
+      bin, args: ['--full-auto', '--quiet', prompt],
+      stdinMode: 'ignore',
       label: 'Codex CLI',
       filterStderr: false,
       onToken, onDone, onError,

--- a/src/main/api/aiClient.js
+++ b/src/main/api/aiClient.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+
+const OLLAMA_PROBE_PATHS = [
+  '/usr/local/bin/ollama',
+  '/opt/homebrew/bin/ollama',
+];
+
+function findOllama() {
+  for (const p of OLLAMA_PROBE_PATHS) {
+    try {
+      fs.accessSync(p, fs.constants.X_OK);
+      return p;
+    } catch {
+      // not at this path
+    }
+  }
+  // Fall back to PATH lookup
+  return 'ollama';
+}
+
+/**
+ * Spawn `ollama run <model>`, pipe the prompt, and stream output tokens.
+ * Returns the child process so the caller can .kill() it to cancel.
+ *
+ * @param {string}   prompt   - Full prompt text to send to the model
+ * @param {string}   model    - Ollama model name (e.g. 'llama3.2')
+ * @param {function} onToken  - Called with each output string chunk
+ * @param {function} onDone   - Called when the process exits cleanly
+ * @param {function} onError  - Called with an error message string
+ * @returns {ChildProcess|null}
+ */
+function generate(prompt, model, onToken, onDone, onError) {
+  const ollamaPath = findOllama();
+
+  const env = {
+    ...process.env,
+    PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH || ''}`,
+  };
+
+  let proc;
+  try {
+    proc = spawn(ollamaPath, ['run', model, '--nowordwrap'], { env });
+  } catch (err) {
+    onError('Failed to start Ollama: ' + err.message);
+    return null;
+  }
+
+  proc.stdin.write(prompt + '\n');
+  proc.stdin.end();
+
+  proc.stdout.on('data', (chunk) => {
+    onToken(chunk.toString());
+  });
+
+  proc.stderr.on('data', (chunk) => {
+    const text = chunk.toString().trim();
+    // Ollama prints model-loading progress to stderr — only surface real errors
+    if (/error/i.test(text)) onError(text);
+  });
+
+  proc.on('close', (code) => {
+    // code === null means killed (user cancel) — no callback needed
+    if (code === 0) onDone();
+  });
+
+  proc.on('error', (err) => {
+    if (err.code === 'ENOENT') {
+      onError('Ollama not found. Install it from https://ollama.com and make sure it is running.');
+    } else {
+      onError('Ollama process error: ' + err.message);
+    }
+  });
+
+  return proc;
+}
+
+module.exports = { generate, findOllama };

--- a/src/main/api/redmineClient.js
+++ b/src/main/api/redmineClient.js
@@ -110,6 +110,20 @@ async function fetchTimeActivities() {
   return res.data.time_entry_activities;
 }
 
+async function fetchIssuesByAssignees(projectId, assigneeIds) {
+  const client = getClient();
+  const results = await Promise.all(
+    assigneeIds.map(id =>
+      client.get('/issues.json', {
+        params: { project_id: projectId, assigned_to_id: id, status_id: 'open', limit: 50 },
+      }).then(r => r.data.issues),
+    ),
+  );
+  const all  = results.flat();
+  const seen = new Set();
+  return all.filter(i => { if (seen.has(i.id)) return false; seen.add(i.id); return true; });
+}
+
 async function fetchChildren(parentId) {
   const client = getClient();
   const res = await client.get('/issues.json', {
@@ -133,4 +147,5 @@ module.exports = {
   updateIssue,
   fetchChildren,
   fetchTimeActivities,
+  fetchIssuesByAssignees,
 };

--- a/src/main/ipc/ai.ipc.js
+++ b/src/main/ipc/ai.ipc.js
@@ -7,7 +7,7 @@ const aiClient = require('../api/aiClient');
 let activeProcess = null;
 
 function register(getMainWindow) {
-  ipcMain.on(IPC.AI_GENERATE, (event, prompt, model = 'llama3.2') => {
+  ipcMain.on(IPC.AI_GENERATE, (event, prompt, backend = 'ollama', model = 'llama3.2') => {
     // Kill any in-flight generation before starting a new one
     if (activeProcess) {
       activeProcess.kill();
@@ -20,6 +20,7 @@ function register(getMainWindow) {
 
     activeProcess = aiClient.generate(
       prompt,
+      backend,
       model,
       (token) => {
         if (!sender.isDestroyed()) sender.send(IPC.AI_TOKEN, token);

--- a/src/main/ipc/ai.ipc.js
+++ b/src/main/ipc/ai.ipc.js
@@ -10,37 +10,52 @@ function register(getMainWindow) {
   ipcMain.on(IPC.AI_GENERATE, (event, prompt, backend = 'ollama', model = 'llama3.2') => {
     // Kill any in-flight generation before starting a new one
     if (activeProcess) {
+      console.log('[AI] Killing previous active process');
       activeProcess.kill();
       activeProcess = null;
     }
 
+    console.log(`[AI] Starting generation — backend=${backend} model=${model} promptLen=${prompt.length}`);
+
     // Prefer the main window's webContents so tokens reach the right renderer
-    const win = getMainWindow ? getMainWindow() : null;
+    const win    = getMainWindow ? getMainWindow() : null;
     const sender = (win && !win.isDestroyed()) ? win.webContents : event.sender;
+
+    let tokenCount = 0;
 
     activeProcess = aiClient.generate(
       prompt,
       backend,
       model,
       (token) => {
+        tokenCount++;
+        if (tokenCount === 1 || tokenCount % 20 === 0) {
+          console.log(`[AI] Token #${tokenCount} (${token.length} chars, total so far)`);
+        }
         if (!sender.isDestroyed()) sender.send(IPC.AI_TOKEN, token);
       },
       () => {
+        console.log(`[AI] Done — ${tokenCount} token chunks received`);
         activeProcess = null;
         if (!sender.isDestroyed()) sender.send(IPC.AI_DONE);
       },
       (err) => {
+        console.error(`[AI] Error — ${err}`);
         activeProcess = null;
         if (!sender.isDestroyed()) sender.send(IPC.AI_ERROR, err);
       },
     );
 
-    // If aiClient returned null (Ollama not found), AI_ERROR was already sent
-    if (!activeProcess) return;
+    if (!activeProcess) {
+      console.warn('[AI] aiClient.generate returned null — error already dispatched');
+    } else {
+      console.log(`[AI] Process spawned (pid=${activeProcess.pid})`);
+    }
   });
 
   ipcMain.on(IPC.AI_CANCEL, () => {
     if (activeProcess) {
+      console.log('[AI] Cancel requested — killing process');
       activeProcess.kill();
       activeProcess = null;
     }

--- a/src/main/ipc/ai.ipc.js
+++ b/src/main/ipc/ai.ipc.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { ipcMain } = require('electron');
+const { IPC } = require('../../shared/constants');
+const aiClient = require('../api/aiClient');
+
+let activeProcess = null;
+
+function register(getMainWindow) {
+  ipcMain.on(IPC.AI_GENERATE, (event, prompt, model = 'llama3.2') => {
+    // Kill any in-flight generation before starting a new one
+    if (activeProcess) {
+      activeProcess.kill();
+      activeProcess = null;
+    }
+
+    // Prefer the main window's webContents so tokens reach the right renderer
+    const win = getMainWindow ? getMainWindow() : null;
+    const sender = (win && !win.isDestroyed()) ? win.webContents : event.sender;
+
+    activeProcess = aiClient.generate(
+      prompt,
+      model,
+      (token) => {
+        if (!sender.isDestroyed()) sender.send(IPC.AI_TOKEN, token);
+      },
+      () => {
+        activeProcess = null;
+        if (!sender.isDestroyed()) sender.send(IPC.AI_DONE);
+      },
+      (err) => {
+        activeProcess = null;
+        if (!sender.isDestroyed()) sender.send(IPC.AI_ERROR, err);
+      },
+    );
+
+    // If aiClient returned null (Ollama not found), AI_ERROR was already sent
+    if (!activeProcess) return;
+  });
+
+  ipcMain.on(IPC.AI_CANCEL, () => {
+    if (activeProcess) {
+      activeProcess.kill();
+      activeProcess = null;
+    }
+  });
+}
+
+module.exports = { register };

--- a/src/main/ipc/code.ipc.js
+++ b/src/main/ipc/code.ipc.js
@@ -77,6 +77,38 @@ function register() {
 
     return { ok: true, files, truncated: totalBytes.n >= MAX_TOTAL_BYTES };
   });
+
+  ipcMain.handle(IPC.CODE_WRITE_PATCH, (_e, dirPath, filename, patchText) => {
+    if (!dirPath || !dirPath.trim()) {
+      return { ok: false, error: 'No directory path provided.' };
+    }
+
+    const resolvedDir = path.resolve(dirPath.trim());
+    try {
+      fs.accessSync(resolvedDir, fs.constants.W_OK);
+    } catch {
+      return { ok: false, error: `Cannot write to directory: ${resolvedDir}` };
+    }
+
+    const safeFilename = path.basename(String(filename || 'ai-generated.patch').trim() || 'ai-generated.patch');
+    if (!safeFilename.endsWith('.patch') && !safeFilename.endsWith('.diff')) {
+      return { ok: false, error: 'Patch filename must end with .patch or .diff.' };
+    }
+
+    const content = String(patchText || '');
+    if (!content.trim()) {
+      return { ok: false, error: 'No patch content provided.' };
+    }
+
+    const targetPath = path.join(resolvedDir, safeFilename);
+    try {
+      fs.writeFileSync(targetPath, content, 'utf-8');
+    } catch (err) {
+      return { ok: false, error: `Failed to write patch: ${err.message}` };
+    }
+
+    return { ok: true, path: targetPath };
+  });
 }
 
 module.exports = { register };

--- a/src/main/ipc/code.ipc.js
+++ b/src/main/ipc/code.ipc.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const { ipcMain } = require('electron');
+const { IPC } = require('../../shared/constants');
+const fs   = require('fs');
+const path = require('path');
+
+const CODE_EXTENSIONS = new Set([
+  '.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs',
+  '.py', '.rb', '.go', '.java', '.cs', '.cpp', '.c', '.h',
+  '.php', '.swift', '.kt', '.rs', '.vue', '.svelte',
+  '.css', '.scss', '.html', '.md',
+  '.json', '.yaml', '.yml', '.toml', '.sh',
+]);
+
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'coverage',
+  '__pycache__', '.next', 'vendor', 'target', '.cache', '.turbo',
+]);
+
+const MAX_FILE_BYTES  = 50  * 1024; // 50 KB per file
+const MAX_TOTAL_BYTES = 200 * 1024; // 200 KB total across all files
+
+function walkDir(dirPath, rootPath, files, totalBytes) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (totalBytes.n >= MAX_TOTAL_BYTES) break;
+
+    const fullPath = path.join(dirPath, entry.name);
+    const relPath  = path.relative(rootPath, fullPath);
+
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walkDir(fullPath, rootPath, files, totalBytes);
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!CODE_EXTENSIONS.has(ext)) continue;
+
+      let stat;
+      try { stat = fs.statSync(fullPath); } catch { continue; }
+      if (stat.size > MAX_FILE_BYTES) continue;
+
+      let content;
+      try { content = fs.readFileSync(fullPath, 'utf-8'); } catch { continue; }
+
+      totalBytes.n += content.length;
+      files.push({ path: relPath, content });
+    }
+  }
+}
+
+function register() {
+  ipcMain.handle(IPC.CODE_READ, (_e, dirPath) => {
+    if (!dirPath || !dirPath.trim()) {
+      return { ok: false, error: 'No directory path provided.' };
+    }
+
+    const resolved = path.resolve(dirPath.trim());
+    try {
+      fs.accessSync(resolved, fs.constants.R_OK);
+    } catch {
+      return { ok: false, error: `Cannot read directory: ${resolved}` };
+    }
+
+    const totalBytes = { n: 0 };
+    const files      = [];
+    walkDir(resolved, resolved, files, totalBytes);
+
+    if (files.length === 0) {
+      return { ok: false, error: 'No supported code files found in that directory.' };
+    }
+
+    return { ok: true, files, truncated: totalBytes.n >= MAX_TOTAL_BYTES };
+  });
+}
+
+module.exports = { register };

--- a/src/main/ipc/git.ipc.js
+++ b/src/main/ipc/git.ipc.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { ipcMain } = require('electron');
+const { IPC } = require('../../shared/constants');
+const { execFile } = require('child_process');
+
+function register() {
+  ipcMain.handle(IPC.GIT_DIFF, (_e, repoPath) => {
+    return new Promise((resolve) => {
+      if (!repoPath || !repoPath.trim()) {
+        return resolve({ ok: false, error: 'No repository path provided.' });
+      }
+
+      execFile(
+        'git', ['diff', 'HEAD'],
+        { cwd: repoPath.trim(), maxBuffer: 4 * 1024 * 1024 },
+        (err, stdout, stderr) => {
+          if (err) {
+            return resolve({ ok: false, error: (stderr || err.message).trim() });
+          }
+          const diff = stdout.trim();
+          if (!diff) {
+            return resolve({ ok: false, error: 'No uncommitted changes (git diff HEAD is empty).' });
+          }
+          resolve({ ok: true, diff });
+        },
+      );
+    });
+  });
+}
+
+module.exports = { register };

--- a/src/main/ipc/index.js
+++ b/src/main/ipc/index.js
@@ -5,6 +5,8 @@ const redmine = require('../api/redmineClient');
 const issuesIpc = require('./issues.ipc');
 const timeIpc = require('./time.ipc');
 const uploadIpc = require('./upload.ipc');
+const aiIpc = require('./ai.ipc');
+const gitIpc = require('./git.ipc');
 const pollerManager = require('../polling/pollerManager');
 const notifications = require('./notifications');
 
@@ -59,6 +61,12 @@ function registerAll(store, getMainWindow) {
 
   // Upload
   uploadIpc.register();
+
+  // AI
+  aiIpc.register(getMainWindow);
+
+  // Git
+  gitIpc.register();
 
   // Start poller if credentials are already configured
   if (credentials.load()) startPoller();

--- a/src/main/ipc/index.js
+++ b/src/main/ipc/index.js
@@ -7,6 +7,7 @@ const timeIpc = require('./time.ipc');
 const uploadIpc = require('./upload.ipc');
 const aiIpc = require('./ai.ipc');
 const gitIpc = require('./git.ipc');
+const codeIpc = require('./code.ipc');
 const pollerManager = require('../polling/pollerManager');
 const notifications = require('./notifications');
 
@@ -67,6 +68,9 @@ function registerAll(store, getMainWindow) {
 
   // Git
   gitIpc.register();
+
+  // Code read
+  codeIpc.register();
 
   // Start poller if credentials are already configured
   if (credentials.load()) startPoller();

--- a/src/main/ipc/issues.ipc.js
+++ b/src/main/ipc/issues.ipc.js
@@ -80,6 +80,24 @@ function register(store) {
       return { ok: false, error: err.message };
     }
   });
+
+  ipcMain.handle(IPC.PROJECTS_LIST, async () => {
+    try {
+      const projects = await redmine.fetchProjects();
+      return { ok: true, projects };
+    } catch (err) {
+      return { ok: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle(IPC.ISSUES_FETCH_BY_ASSIGNEES, async (_e, projectId, assigneeIds) => {
+    try {
+      const issues = await redmine.fetchIssuesByAssignees(projectId, assigneeIds);
+      return { ok: true, issues };
+    } catch (err) {
+      return { ok: false, error: err.message };
+    }
+  });
 }
 
 module.exports = { register };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -23,6 +23,7 @@ contextBridge.exposeInMainWorld('redmine', {
   },
   code: {
     read: (dirPath) => ipcRenderer.invoke(IPC.CODE_READ, dirPath),
+    writePatch: (dirPath, filename, patchText) => ipcRenderer.invoke(IPC.CODE_WRITE_PATCH, dirPath, filename, patchText),
   },
   time: {
     log: (entry) => ipcRenderer.invoke(IPC.TIME_LOG, entry),

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -35,7 +35,7 @@ contextBridge.exposeInMainWorld('redmine', {
     set: (key, value) => ipcRenderer.invoke(IPC.SETTINGS_SET, key, value),
   },
   ai: {
-    generate: (prompt, model) => ipcRenderer.send(IPC.AI_GENERATE, prompt, model),
+    generate: (prompt, backend, model) => ipcRenderer.send(IPC.AI_GENERATE, prompt, backend, model),
     cancel: () => ipcRenderer.send(IPC.AI_CANCEL),
   },
   git: {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld('redmine', {
   },
   projects: {
     members: (id) => ipcRenderer.invoke(IPC.PROJECT_MEMBERS, id),
+    list: ()     => ipcRenderer.invoke(IPC.PROJECTS_LIST),
   },
   issues: {
     fetch: () => ipcRenderer.invoke(IPC.ISSUES_FETCH),
@@ -18,6 +19,10 @@ contextBridge.exposeInMainWorld('redmine', {
     update: (id, fields) => ipcRenderer.invoke(IPC.ISSUES_UPDATE, id, fields),
     fetchChildren: (id) => ipcRenderer.invoke(IPC.ISSUES_FETCH_CHILDREN, id),
     statuses: () => ipcRenderer.invoke(IPC.ISSUES_STATUSES),
+    fetchByAssignees: (projectId, assigneeIds) => ipcRenderer.invoke(IPC.ISSUES_FETCH_BY_ASSIGNEES, projectId, assigneeIds),
+  },
+  code: {
+    read: (dirPath) => ipcRenderer.invoke(IPC.CODE_READ, dirPath),
   },
   time: {
     log: (entry) => ipcRenderer.invoke(IPC.TIME_LOG, entry),

--- a/src/renderer/css/ai.css
+++ b/src/renderer/css/ai.css
@@ -1,0 +1,118 @@
+/* ── AI Panel ──────────────────────────────────────────────────────────────── */
+
+.ai-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  max-width: 800px;
+}
+
+.ai-config {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ai-config-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ai-config-row .ai-label {
+  width: 60px;
+  flex-shrink: 0;
+}
+
+.ai-config-row select,
+.ai-config-row input {
+  flex: 1;
+}
+
+.ai-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+  display: block;
+}
+
+.ai-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ai-section textarea {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--input-bg, var(--bg));
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 13px;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.ai-diff-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.ai-diff-row input {
+  flex: 1;
+}
+
+.ai-status {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.ai-status-ok    { color: var(--success); }
+.ai-status-error { color: var(--danger);  }
+
+.ai-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.ai-error {
+  font-size: 13px;
+  color: var(--danger);
+  background: rgba(220, 53, 69, 0.08);
+  border: 1px solid var(--danger);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.ai-output-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ai-output {
+  background: var(--bg-secondary, rgba(255,255,255,0.04));
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 360px;
+  overflow-y: auto;
+  margin: 0;
+  color: var(--text);
+  line-height: 1.6;
+}

--- a/src/renderer/css/ai.css
+++ b/src/renderer/css/ai.css
@@ -75,6 +75,11 @@
   margin: 0;
 }
 
+.ai-status-pending {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 .ai-status-ok    { color: var(--success); }
 .ai-status-error { color: var(--danger);  }
 
@@ -115,6 +120,19 @@
   gap: 4px;
 }
 
+.ai-code-patch-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text);
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.ai-code-patch-toggle input {
+  margin: 0;
+}
+
 .ai-team-members-row select {
   width: 100%;
   background: var(--input-bg, var(--bg));
@@ -151,4 +169,27 @@
   margin: 0;
   color: var(--text);
   line-height: 1.6;
+}
+
+.ai-output-waiting {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.ai-output-waiting::before {
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-right: 8px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 999px;
+  vertical-align: -2px;
+  animation: ai-spin 0.8s linear infinite;
+}
+
+@keyframes ai-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
 }

--- a/src/renderer/css/ai.css
+++ b/src/renderer/css/ai.css
@@ -101,6 +101,42 @@
   gap: 4px;
 }
 
+.ai-hint {
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.ai-team-members-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ai-team-members-row select {
+  width: 100%;
+  background: var(--input-bg, var(--bg));
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 6px;
+  font-size: 13px;
+}
+
+.ai-section input[type="text"],
+.ai-section input[type="number"] {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--input-bg, var(--bg));
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-size: 13px;
+}
+
 .ai-output {
   background: var(--bg-secondary, rgba(255,255,255,0.04));
   border: 1px solid var(--border);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -11,12 +11,14 @@
   <link rel="stylesheet" href="css/theme-dark.css" id="theme-dark" disabled />
   <link rel="stylesheet" href="css/components.css" />
   <link rel="stylesheet" href="css/issues.css" />
+  <link rel="stylesheet" href="css/ai.css" />
 </head>
 <body>
   <div id="app">
     <nav id="sidebar">
       <button class="nav-btn active" data-view="issues">Issues</button>
       <button class="nav-btn" data-view="time">Time</button>
+      <button class="nav-btn" data-view="ai">AI</button>
       <button class="nav-btn" data-view="settings">Settings</button>
     </nav>
     <main id="content"></main>

--- a/src/renderer/js/app.js
+++ b/src/renderer/js/app.js
@@ -1,6 +1,7 @@
 import { renderSettings } from './views/settings.js';
 import { renderIssueList } from './views/issueList.js';
 import { renderTimeLog } from './views/timeLog.js';
+import { renderAiPanel } from './views/aiPanel.js';
 
 const content = document.getElementById('content');
 
@@ -28,6 +29,8 @@ async function navigate(view) {
     await renderIssueList(content);
   } else if (view === 'time') {
     await renderTimeLog(content);
+  } else if (view === 'ai') {
+    await renderAiPanel(content);
   }
 }
 

--- a/src/renderer/js/views/aiPanel.js
+++ b/src/renderer/js/views/aiPanel.js
@@ -6,21 +6,44 @@ function escHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
+// section: which input section to show for this mode
 const MODES = {
-  ac:       { label: 'Generate Acceptance Criteria', needsDiff: false },
-  subtasks: { label: 'Generate Sub-tasks',           needsDiff: false },
-  diff:     { label: 'Summarize Git Diff',           needsDiff: true  },
+  ac:       { label: 'Generate Acceptance Criteria', section: 'context' },
+  subtasks: { label: 'Generate Sub-tasks',           section: 'context' },
+  diff:     { label: 'Summarize Git Diff',           section: 'diff'    },
+  team:     { label: 'Analyze Team Tickets',         section: 'team'    },
+  code:     { label: 'Analyze Code + Issue',         section: 'code'    },
 };
 
-function buildPrompt(mode, context, diff) {
+function buildPrompt(mode, { context, diff, tickets, issueText, codeText }) {
   if (mode === 'ac') {
     return `You are a senior software engineer. Given the following issue description, write clear Acceptance Criteria in checklist format (use "- [ ] " prefix for each item).\n\nIssue:\n${context}`;
   }
   if (mode === 'subtasks') {
     return `You are a senior software engineer. Given the following issue description, break it into specific, implementable sub-tasks as a checklist (use "- [ ] " prefix for each item).\n\nIssue:\n${context}`;
   }
-  // diff
-  return `Summarize the following git diff as a concise Redmine journal note. Describe what changed and why (inferred from the diff). Keep it under 200 words.\n\nDiff:\n${diff}`;
+  if (mode === 'diff') {
+    return `Summarize the following git diff as a concise Redmine journal note. Describe what changed and why (inferred from the diff). Keep it under 200 words.\n\nDiff:\n${diff}`;
+  }
+  if (mode === 'team') {
+    return `You are an experienced engineering manager. Below are open Redmine tickets assigned to one or more team members. Analyze patterns, recurring blockers, risks, and workload. Provide clear, prioritized recommendations to improve the team's delivery.\n\nTickets:\n${tickets}`;
+  }
+  // code
+  return `You are a senior software engineer. Given the issue below and the relevant source files, analyze the root cause and suggest specific code changes to resolve the issue. Reference file names where possible.\n\nIssue:\n${issueText}\n\nSource files:\n${codeText}`;
+}
+
+function formatTickets(issues) {
+  return issues.map(i =>
+    `#${i.id} [${i.status?.name || '?'}] ${i.subject}\n` +
+    `  Assigned: ${i.assigned_to?.name || 'Unassigned'} | Priority: ${i.priority?.name || 'Normal'} | Updated: ${(i.updated_on || '').slice(0, 10)}\n` +
+    (i.description ? `  ${i.description.replace(/\n/g, ' ').slice(0, 300)}` : '  (no description)')
+  ).join('\n\n');
+}
+
+function formatCodeFiles(files) {
+  return files.map(f =>
+    `=== ${f.path} ===\n${f.content}`
+  ).join('\n\n');
 }
 
 export async function renderAiPanel(container) {
@@ -49,11 +72,13 @@ export async function renderAiPanel(container) {
         </div>
       </div>
 
+      <!-- Context (ac / subtasks) -->
       <div id="ai-context-section" class="ai-section">
         <label class="ai-label">Issue description / context</label>
         <textarea id="ai-context" rows="6" placeholder="Paste or type the issue description here…"></textarea>
       </div>
 
+      <!-- Git diff -->
       <div id="ai-diff-section" class="ai-section" style="display:none">
         <label class="ai-label">Git repository path</label>
         <div class="ai-diff-row">
@@ -62,6 +87,30 @@ export async function renderAiPanel(container) {
         </div>
         <p id="ai-diff-status" class="ai-status" style="display:none"></p>
         <textarea id="ai-diff-preview" rows="5" placeholder="Git diff will appear here…" readonly style="display:none"></textarea>
+      </div>
+
+      <!-- Team analysis -->
+      <div id="ai-team-section" class="ai-section" style="display:none">
+        <div class="ai-config-row">
+          <label class="ai-label">Project</label>
+          <select id="ai-team-project"><option value="">— loading projects… —</option></select>
+        </div>
+        <div class="ai-team-members-row">
+          <label class="ai-label">Members <span class="ai-hint">(Ctrl/Cmd+click to select multiple)</span></label>
+          <select id="ai-team-members" multiple size="4"></select>
+        </div>
+        <button class="btn btn-secondary" id="btn-load-tickets" style="margin-top:6px">Load Tickets</button>
+        <p id="ai-team-status" class="ai-status" style="display:none"></p>
+      </div>
+
+      <!-- Code + issue analysis -->
+      <div id="ai-code-section" class="ai-section" style="display:none">
+        <label class="ai-label">Code directory</label>
+        <input id="ai-code-dir" type="text" placeholder="/path/to/project/src" />
+        <label class="ai-label" style="margin-top:8px">Issue ID</label>
+        <input id="ai-issue-id" type="number" placeholder="e.g. 42" min="1" />
+        <button class="btn btn-secondary" id="btn-load-code" style="margin-top:8px">Load Code &amp; Issue</button>
+        <p id="ai-code-status" class="ai-status" style="display:none"></p>
       </div>
 
       <div class="ai-actions">
@@ -80,34 +129,61 @@ export async function renderAiPanel(container) {
     </div>
   `;
 
+  // ── Element refs ──────────────────────────────────────────────────────────
   const modeEl         = container.querySelector('#ai-mode');
   const backendEl      = container.querySelector('#ai-backend');
   const modelRowEl     = container.querySelector('#ai-model-row');
   const modelEl        = container.querySelector('#ai-model');
-  const contextSection = container.querySelector('#ai-context-section');
-  const contextEl      = container.querySelector('#ai-context');
-  const diffSection    = container.querySelector('#ai-diff-section');
-  const repoPathEl     = container.querySelector('#ai-repo-path');
-  const diffStatusEl   = container.querySelector('#ai-diff-status');
-  const diffPreviewEl  = container.querySelector('#ai-diff-preview');
   const outputSection  = container.querySelector('#ai-output-section');
   const outputEl       = container.querySelector('#ai-output');
   const errorEl        = container.querySelector('#ai-error');
   const btnGenerate    = container.querySelector('#btn-ai-generate');
   const btnCancel      = container.querySelector('#btn-ai-cancel');
   const btnClear       = container.querySelector('#btn-ai-clear');
-  const btnLoadDiff    = container.querySelector('#btn-load-diff');
   const btnCopy        = container.querySelector('#btn-ai-copy');
 
-  let currentDiff = '';
+  // Sections
+  const sectionEls = {
+    context: container.querySelector('#ai-context-section'),
+    diff:    container.querySelector('#ai-diff-section'),
+    team:    container.querySelector('#ai-team-section'),
+    code:    container.querySelector('#ai-code-section'),
+  };
 
-  function showError(msg) {
-    errorEl.textContent = msg;
-    errorEl.style.display = '';
-  }
+  // Context
+  const contextEl = container.querySelector('#ai-context');
 
-  function hideError() {
-    errorEl.style.display = 'none';
+  // Diff
+  const repoPathEl   = container.querySelector('#ai-repo-path');
+  const diffStatusEl = container.querySelector('#ai-diff-status');
+  const diffPreviewEl= container.querySelector('#ai-diff-preview');
+
+  // Team
+  const teamProjectEl = container.querySelector('#ai-team-project');
+  const teamMembersEl = container.querySelector('#ai-team-members');
+  const teamStatusEl  = container.querySelector('#ai-team-status');
+  const btnLoadTickets= container.querySelector('#btn-load-tickets');
+
+  // Code
+  const codeDirEl    = container.querySelector('#ai-code-dir');
+  const issueIdEl    = container.querySelector('#ai-issue-id');
+  const codeStatusEl = container.querySelector('#ai-code-status');
+  const btnLoadCode  = container.querySelector('#btn-load-code');
+
+  // ── State ─────────────────────────────────────────────────────────────────
+  let currentDiff    = '';
+  let currentTickets = '';
+  let currentIssueText = '';
+  let currentCodeText  = '';
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+  function showError(msg)  { errorEl.textContent = msg; errorEl.style.display = ''; }
+  function hideError()     { errorEl.style.display = 'none'; }
+
+  function setStatus(el, msg, type = '') {
+    el.textContent = msg;
+    el.className   = 'ai-status' + (type ? ` ai-status-${type}` : '');
+    el.style.display = msg ? '' : 'none';
   }
 
   function setGenerating(on) {
@@ -115,57 +191,150 @@ export async function renderAiPanel(container) {
     btnCancel.disabled   = !on;
   }
 
-  // Backend switch — hide model input for Claude/Codex (no model needed)
+  function showSection(key) {
+    Object.entries(sectionEls).forEach(([k, el]) => {
+      el.style.display = k === key ? '' : 'none';
+    });
+  }
+
+  // ── Backend / mode switches ───────────────────────────────────────────────
   backendEl.addEventListener('change', () => {
     modelRowEl.style.display = backendEl.value === 'ollama' ? '' : 'none';
   });
 
-  // Mode switch
   modeEl.addEventListener('change', () => {
-    const needsDiff = MODES[modeEl.value].needsDiff;
-    contextSection.style.display = needsDiff ? 'none' : '';
-    diffSection.style.display    = needsDiff ? '' : 'none';
+    showSection(MODES[modeEl.value].section);
   });
 
-  // Load git diff
-  btnLoadDiff.addEventListener('click', async () => {
+  // ── Load git diff ─────────────────────────────────────────────────────────
+  container.querySelector('#btn-load-diff').addEventListener('click', async () => {
     const repoPath = repoPathEl.value.trim();
     if (!repoPath) return;
 
-    diffStatusEl.textContent = 'Loading…';
-    diffStatusEl.className   = 'ai-status';
-    diffStatusEl.style.display = '';
-
+    setStatus(diffStatusEl, 'Loading…');
     const result = await window.redmine.git.diff(repoPath);
     if (result.ok) {
       currentDiff = result.diff;
       diffPreviewEl.value = result.diff;
       diffPreviewEl.style.display = '';
-      const lines = result.diff.split('\n').length;
-      diffStatusEl.textContent = `Loaded — ${lines} lines`;
-      diffStatusEl.className   = 'ai-status ai-status-ok';
+      setStatus(diffStatusEl, `Loaded — ${result.diff.split('\n').length} lines`, 'ok');
     } else {
       currentDiff = '';
       diffPreviewEl.style.display = 'none';
-      diffStatusEl.textContent = 'Error: ' + result.error;
-      diffStatusEl.className   = 'ai-status ai-status-error';
+      setStatus(diffStatusEl, 'Error: ' + result.error, 'error');
     }
   });
 
-  // Generate
+  // ── Load projects for team mode ───────────────────────────────────────────
+  async function loadProjects() {
+    const result = await window.redmine.projects.list();
+    if (!result.ok) {
+      teamProjectEl.innerHTML = `<option value="">Failed: ${escHtml(result.error)}</option>`;
+      return;
+    }
+    teamProjectEl.innerHTML =
+      `<option value="">— select a project —</option>` +
+      result.projects.map(p => `<option value="${p.id}">${escHtml(p.name)}</option>`).join('');
+  }
+
+  teamProjectEl.addEventListener('change', async () => {
+    const projectId = teamProjectEl.value;
+    teamMembersEl.innerHTML = '<option disabled>Loading…</option>';
+    if (!projectId) return;
+
+    const result = await window.redmine.projects.members(projectId);
+    if (result.ok) {
+      teamMembersEl.innerHTML = result.members.map(m =>
+        `<option value="${m.id}">${escHtml(m.name)}</option>`
+      ).join('');
+    } else {
+      teamMembersEl.innerHTML = `<option disabled>Failed: ${escHtml(result.error)}</option>`;
+    }
+  });
+
+  btnLoadTickets.addEventListener('click', async () => {
+    const projectId = teamProjectEl.value;
+    if (!projectId) { setStatus(teamStatusEl, 'Select a project first.', 'error'); return; }
+
+    const selectedIds = Array.from(teamMembersEl.selectedOptions).map(o => Number(o.value));
+    if (selectedIds.length === 0) { setStatus(teamStatusEl, 'Select at least one member.', 'error'); return; }
+
+    setStatus(teamStatusEl, 'Loading tickets…');
+    const result = await window.redmine.issues.fetchByAssignees(projectId, selectedIds);
+    if (result.ok) {
+      currentTickets = formatTickets(result.issues);
+      setStatus(teamStatusEl, `Loaded ${result.issues.length} ticket(s)`, 'ok');
+    } else {
+      currentTickets = '';
+      setStatus(teamStatusEl, 'Error: ' + result.error, 'error');
+    }
+  });
+
+  // ── Load code + issue ─────────────────────────────────────────────────────
+  btnLoadCode.addEventListener('click', async () => {
+    const dir     = codeDirEl.value.trim();
+    const issueId = Number(issueIdEl.value);
+
+    if (!dir)     { setStatus(codeStatusEl, 'Enter a directory path.', 'error'); return; }
+    if (!issueId) { setStatus(codeStatusEl, 'Enter a valid issue ID.', 'error'); return; }
+
+    setStatus(codeStatusEl, 'Loading…');
+
+    const [codeResult, issueResult] = await Promise.all([
+      window.redmine.code.read(dir),
+      window.redmine.issues.get(issueId),
+    ]);
+
+    const errors = [];
+    if (codeResult.ok) {
+      currentCodeText = formatCodeFiles(codeResult.files);
+      if (codeResult.truncated) errors.push('Code truncated to 200 KB.');
+    } else {
+      currentCodeText = '';
+      errors.push('Code: ' + codeResult.error);
+    }
+
+    if (issueResult.ok) {
+      const i = issueResult.issue;
+      currentIssueText = `#${i.id} — ${i.subject}\n${i.description || '(no description)'}`;
+    } else {
+      currentIssueText = '';
+      errors.push('Issue: ' + issueResult.error);
+    }
+
+    if (errors.length) {
+      setStatus(codeStatusEl, errors.join(' | '), currentCodeText && currentIssueText ? '' : 'error');
+    } else {
+      const fileCount = codeResult.files.length;
+      setStatus(codeStatusEl, `Loaded ${fileCount} file(s) + issue #${issueId}`, 'ok');
+    }
+  });
+
+  // ── Generate ──────────────────────────────────────────────────────────────
   btnGenerate.addEventListener('click', () => {
     hideError();
     const mode    = modeEl.value;
     const backend = backendEl.value;
     const model   = modelEl.value.trim() || 'llama3.2';
 
-    if (MODES[mode].needsDiff) {
-      if (!currentDiff) { showError('Load a git diff first.'); return; }
-    } else {
+    // Validate inputs per mode
+    if (mode === 'ac' || mode === 'subtasks') {
       if (!contextEl.value.trim()) { showError('Enter an issue description first.'); return; }
+    } else if (mode === 'diff') {
+      if (!currentDiff) { showError('Load a git diff first.'); return; }
+    } else if (mode === 'team') {
+      if (!currentTickets) { showError('Load tickets first.'); return; }
+    } else if (mode === 'code') {
+      if (!currentCodeText || !currentIssueText) { showError('Load code and issue first.'); return; }
     }
 
-    const prompt = buildPrompt(mode, contextEl.value.trim(), currentDiff);
+    const prompt = buildPrompt(mode, {
+      context:    contextEl.value.trim(),
+      diff:       currentDiff,
+      tickets:    currentTickets,
+      issueText:  currentIssueText,
+      codeText:   currentCodeText,
+    });
 
     outputEl.textContent = '';
     outputSection.style.display = '';
@@ -174,13 +343,11 @@ export async function renderAiPanel(container) {
     window.redmine.ai.generate(prompt, backend, model);
   });
 
-  // Cancel
   btnCancel.addEventListener('click', () => {
     window.redmine.ai.cancel();
     setGenerating(false);
   });
 
-  // Clear
   btnClear.addEventListener('click', () => {
     outputEl.textContent = '';
     outputSection.style.display = 'none';
@@ -188,14 +355,13 @@ export async function renderAiPanel(container) {
     setGenerating(false);
   });
 
-  // Copy
   btnCopy.addEventListener('click', () => {
     navigator.clipboard.writeText(outputEl.textContent);
     btnCopy.textContent = 'Copied!';
     setTimeout(() => { btnCopy.textContent = 'Copy to Clipboard'; }, 2000);
   });
 
-  // AI streaming — check element is still in DOM before updating
+  // ── AI streaming ──────────────────────────────────────────────────────────
   window.redmine.on('ai:token', (token) => {
     if (!document.contains(outputEl)) return;
     outputEl.textContent += token;
@@ -212,4 +378,7 @@ export async function renderAiPanel(container) {
     setGenerating(false);
     showError(err);
   });
+
+  // Load projects when team mode is first shown
+  loadProjects();
 }

--- a/src/renderer/js/views/aiPanel.js
+++ b/src/renderer/js/views/aiPanel.js
@@ -1,0 +1,199 @@
+function escHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+const MODES = {
+  ac:       { label: 'Generate Acceptance Criteria', needsDiff: false },
+  subtasks: { label: 'Generate Sub-tasks',           needsDiff: false },
+  diff:     { label: 'Summarize Git Diff',           needsDiff: true  },
+};
+
+function buildPrompt(mode, context, diff) {
+  if (mode === 'ac') {
+    return `You are a senior software engineer. Given the following issue description, write clear Acceptance Criteria in checklist format (use "- [ ] " prefix for each item).\n\nIssue:\n${context}`;
+  }
+  if (mode === 'subtasks') {
+    return `You are a senior software engineer. Given the following issue description, break it into specific, implementable sub-tasks as a checklist (use "- [ ] " prefix for each item).\n\nIssue:\n${context}`;
+  }
+  // diff
+  return `Summarize the following git diff as a concise Redmine journal note. Describe what changed and why (inferred from the diff). Keep it under 200 words.\n\nDiff:\n${diff}`;
+}
+
+export async function renderAiPanel(container) {
+  container.innerHTML = `
+    <div class="ai-panel">
+      <div class="ai-config">
+        <div class="ai-config-row">
+          <label class="ai-label">Mode</label>
+          <select id="ai-mode">
+            ${Object.entries(MODES).map(([k, v]) =>
+              `<option value="${k}">${escHtml(v.label)}</option>`
+            ).join('')}
+          </select>
+        </div>
+        <div class="ai-config-row">
+          <label class="ai-label">Model</label>
+          <input id="ai-model" type="text" value="llama3.2" placeholder="e.g. llama3.2, codellama" />
+        </div>
+      </div>
+
+      <div id="ai-context-section" class="ai-section">
+        <label class="ai-label">Issue description / context</label>
+        <textarea id="ai-context" rows="6" placeholder="Paste or type the issue description here…"></textarea>
+      </div>
+
+      <div id="ai-diff-section" class="ai-section" style="display:none">
+        <label class="ai-label">Git repository path</label>
+        <div class="ai-diff-row">
+          <input id="ai-repo-path" type="text" placeholder="/path/to/your/repo" />
+          <button class="btn btn-secondary" id="btn-load-diff">Load Diff</button>
+        </div>
+        <p id="ai-diff-status" class="ai-status" style="display:none"></p>
+        <textarea id="ai-diff-preview" rows="5" placeholder="Git diff will appear here…" readonly style="display:none"></textarea>
+      </div>
+
+      <div class="ai-actions">
+        <button class="btn btn-primary" id="btn-ai-generate">Generate</button>
+        <button class="btn btn-secondary" id="btn-ai-cancel" disabled>Cancel</button>
+        <button class="btn" id="btn-ai-clear">Clear</button>
+      </div>
+
+      <p id="ai-error" class="ai-error" style="display:none"></p>
+
+      <div id="ai-output-section" class="ai-output-section" style="display:none">
+        <div class="ai-label">Output</div>
+        <pre id="ai-output" class="ai-output"></pre>
+        <button class="btn btn-secondary" id="btn-ai-copy" style="margin-top:6px">Copy to Clipboard</button>
+      </div>
+    </div>
+  `;
+
+  const modeEl         = container.querySelector('#ai-mode');
+  const modelEl        = container.querySelector('#ai-model');
+  const contextSection = container.querySelector('#ai-context-section');
+  const contextEl      = container.querySelector('#ai-context');
+  const diffSection    = container.querySelector('#ai-diff-section');
+  const repoPathEl     = container.querySelector('#ai-repo-path');
+  const diffStatusEl   = container.querySelector('#ai-diff-status');
+  const diffPreviewEl  = container.querySelector('#ai-diff-preview');
+  const outputSection  = container.querySelector('#ai-output-section');
+  const outputEl       = container.querySelector('#ai-output');
+  const errorEl        = container.querySelector('#ai-error');
+  const btnGenerate    = container.querySelector('#btn-ai-generate');
+  const btnCancel      = container.querySelector('#btn-ai-cancel');
+  const btnClear       = container.querySelector('#btn-ai-clear');
+  const btnLoadDiff    = container.querySelector('#btn-load-diff');
+  const btnCopy        = container.querySelector('#btn-ai-copy');
+
+  let currentDiff = '';
+
+  function showError(msg) {
+    errorEl.textContent = msg;
+    errorEl.style.display = '';
+  }
+
+  function hideError() {
+    errorEl.style.display = 'none';
+  }
+
+  function setGenerating(on) {
+    btnGenerate.disabled = on;
+    btnCancel.disabled   = !on;
+  }
+
+  // Mode switch
+  modeEl.addEventListener('change', () => {
+    const needsDiff = MODES[modeEl.value].needsDiff;
+    contextSection.style.display = needsDiff ? 'none' : '';
+    diffSection.style.display    = needsDiff ? '' : 'none';
+  });
+
+  // Load git diff
+  btnLoadDiff.addEventListener('click', async () => {
+    const repoPath = repoPathEl.value.trim();
+    if (!repoPath) return;
+
+    diffStatusEl.textContent = 'Loading…';
+    diffStatusEl.className   = 'ai-status';
+    diffStatusEl.style.display = '';
+
+    const result = await window.redmine.git.diff(repoPath);
+    if (result.ok) {
+      currentDiff = result.diff;
+      diffPreviewEl.value = result.diff;
+      diffPreviewEl.style.display = '';
+      const lines = result.diff.split('\n').length;
+      diffStatusEl.textContent = `Loaded — ${lines} lines`;
+      diffStatusEl.className   = 'ai-status ai-status-ok';
+    } else {
+      currentDiff = '';
+      diffPreviewEl.style.display = 'none';
+      diffStatusEl.textContent = 'Error: ' + result.error;
+      diffStatusEl.className   = 'ai-status ai-status-error';
+    }
+  });
+
+  // Generate
+  btnGenerate.addEventListener('click', () => {
+    hideError();
+    const mode  = modeEl.value;
+    const model = modelEl.value.trim() || 'llama3.2';
+
+    if (MODES[mode].needsDiff) {
+      if (!currentDiff) { showError('Load a git diff first.'); return; }
+    } else {
+      if (!contextEl.value.trim()) { showError('Enter an issue description first.'); return; }
+    }
+
+    const prompt = buildPrompt(mode, contextEl.value.trim(), currentDiff);
+
+    outputEl.textContent = '';
+    outputSection.style.display = '';
+    setGenerating(true);
+
+    window.redmine.ai.generate(prompt, model);
+  });
+
+  // Cancel
+  btnCancel.addEventListener('click', () => {
+    window.redmine.ai.cancel();
+    setGenerating(false);
+  });
+
+  // Clear
+  btnClear.addEventListener('click', () => {
+    outputEl.textContent = '';
+    outputSection.style.display = 'none';
+    hideError();
+    setGenerating(false);
+  });
+
+  // Copy
+  btnCopy.addEventListener('click', () => {
+    navigator.clipboard.writeText(outputEl.textContent);
+    btnCopy.textContent = 'Copied!';
+    setTimeout(() => { btnCopy.textContent = 'Copy to Clipboard'; }, 2000);
+  });
+
+  // AI streaming — check element is still in DOM before updating
+  window.redmine.on('ai:token', (token) => {
+    if (!document.contains(outputEl)) return;
+    outputEl.textContent += token;
+    outputEl.scrollTop = outputEl.scrollHeight;
+  });
+
+  window.redmine.on('ai:done', () => {
+    if (!document.contains(btnGenerate)) return;
+    setGenerating(false);
+  });
+
+  window.redmine.on('ai:error', (err) => {
+    if (!document.contains(errorEl)) return;
+    setGenerating(false);
+    showError(err);
+  });
+}

--- a/src/renderer/js/views/aiPanel.js
+++ b/src/renderer/js/views/aiPanel.js
@@ -227,14 +227,18 @@ export async function renderAiPanel(container) {
 
   // ── Load projects for team mode ───────────────────────────────────────────
   async function loadProjects() {
-    const result = await window.redmine.projects.list();
-    if (!result.ok) {
-      teamProjectEl.innerHTML = `<option value="">Failed: ${escHtml(result.error)}</option>`;
-      return;
+    try {
+      const result = await window.redmine.projects.list();
+      if (!result.ok) {
+        teamProjectEl.innerHTML = `<option value="">Failed to load projects</option>`;
+        return;
+      }
+      teamProjectEl.innerHTML =
+        `<option value="">— select a project —</option>` +
+        result.projects.map(p => `<option value="${p.id}">${escHtml(p.name)}</option>`).join('');
+    } catch (err) {
+      teamProjectEl.innerHTML = `<option value="">Error: ${escHtml(err.message)}</option>`;
     }
-    teamProjectEl.innerHTML =
-      `<option value="">— select a project —</option>` +
-      result.projects.map(p => `<option value="${p.id}">${escHtml(p.name)}</option>`).join('');
   }
 
   teamProjectEl.addEventListener('change', async () => {
@@ -242,13 +246,17 @@ export async function renderAiPanel(container) {
     teamMembersEl.innerHTML = '<option disabled>Loading…</option>';
     if (!projectId) return;
 
-    const result = await window.redmine.projects.members(projectId);
-    if (result.ok) {
-      teamMembersEl.innerHTML = result.members.map(m =>
-        `<option value="${m.id}">${escHtml(m.name)}</option>`
-      ).join('');
-    } else {
-      teamMembersEl.innerHTML = `<option disabled>Failed: ${escHtml(result.error)}</option>`;
+    try {
+      const result = await window.redmine.projects.members(projectId);
+      if (result.ok) {
+        teamMembersEl.innerHTML = result.members.map(m =>
+          `<option value="${m.id}">${escHtml(m.name)}</option>`
+        ).join('');
+      } else {
+        teamMembersEl.innerHTML = `<option disabled>Failed: ${escHtml(result.error)}</option>`;
+      }
+    } catch (err) {
+      teamMembersEl.innerHTML = `<option disabled>Error: ${escHtml(err.message)}</option>`;
     }
   });
 
@@ -260,13 +268,17 @@ export async function renderAiPanel(container) {
     if (selectedIds.length === 0) { setStatus(teamStatusEl, 'Select at least one member.', 'error'); return; }
 
     setStatus(teamStatusEl, 'Loading tickets…');
-    const result = await window.redmine.issues.fetchByAssignees(projectId, selectedIds);
-    if (result.ok) {
-      currentTickets = formatTickets(result.issues);
-      setStatus(teamStatusEl, `Loaded ${result.issues.length} ticket(s)`, 'ok');
-    } else {
-      currentTickets = '';
-      setStatus(teamStatusEl, 'Error: ' + result.error, 'error');
+    try {
+      const result = await window.redmine.issues.fetchByAssignees(projectId, selectedIds);
+      if (result.ok) {
+        currentTickets = formatTickets(result.issues);
+        setStatus(teamStatusEl, `Loaded ${result.issues.length} ticket(s)`, 'ok');
+      } else {
+        currentTickets = '';
+        setStatus(teamStatusEl, 'Error: ' + result.error, 'error');
+      }
+    } catch (err) {
+      setStatus(teamStatusEl, 'Error: ' + err.message, 'error');
     }
   });
 
@@ -280,33 +292,38 @@ export async function renderAiPanel(container) {
 
     setStatus(codeStatusEl, 'Loading…');
 
-    const [codeResult, issueResult] = await Promise.all([
-      window.redmine.code.read(dir),
-      window.redmine.issues.get(issueId),
-    ]);
+    try {
+      const [codeResult, issueResult] = await Promise.all([
+        window.redmine.code.read(dir),
+        window.redmine.issues.get(issueId),
+      ]);
 
-    const errors = [];
-    if (codeResult.ok) {
-      currentCodeText = formatCodeFiles(codeResult.files);
-      if (codeResult.truncated) errors.push('Code truncated to 200 KB.');
-    } else {
-      currentCodeText = '';
-      errors.push('Code: ' + codeResult.error);
-    }
+      const errors = [];
+      if (codeResult.ok) {
+        currentCodeText = formatCodeFiles(codeResult.files);
+        if (codeResult.truncated) errors.push('Code truncated to 200 KB.');
+      } else {
+        currentCodeText = '';
+        errors.push('Code: ' + codeResult.error);
+      }
 
-    if (issueResult.ok) {
-      const i = issueResult.issue;
-      currentIssueText = `#${i.id} — ${i.subject}\n${i.description || '(no description)'}`;
-    } else {
+      if (issueResult.ok) {
+        const i = issueResult.issue;
+        currentIssueText = `#${i.id} — ${i.subject}\n${i.description || '(no description)'}`;
+      } else {
+        currentIssueText = '';
+        errors.push('Issue: ' + issueResult.error);
+      }
+
+      if (errors.length) {
+        setStatus(codeStatusEl, errors.join(' | '), currentCodeText && currentIssueText ? '' : 'error');
+      } else {
+        setStatus(codeStatusEl, `Loaded ${codeResult.files.length} file(s) + issue #${issueId}`, 'ok');
+      }
+    } catch (err) {
+      currentCodeText  = '';
       currentIssueText = '';
-      errors.push('Issue: ' + issueResult.error);
-    }
-
-    if (errors.length) {
-      setStatus(codeStatusEl, errors.join(' | '), currentCodeText && currentIssueText ? '' : 'error');
-    } else {
-      const fileCount = codeResult.files.length;
-      setStatus(codeStatusEl, `Loaded ${fileCount} file(s) + issue #${issueId}`, 'ok');
+      setStatus(codeStatusEl, 'Error: ' + err.message, 'error');
     }
   });
 

--- a/src/renderer/js/views/aiPanel.js
+++ b/src/renderer/js/views/aiPanel.js
@@ -15,7 +15,31 @@ const MODES = {
   code:     { label: 'Analyze Code + Issue',         section: 'code'    },
 };
 
-function buildPrompt(mode, { context, diff, tickets, issueText, codeText }) {
+const BACKEND_LABELS = {
+  ollama: 'Ollama',
+  claude: 'Claude CLI',
+  codex: 'Codex CLI',
+};
+
+function buildCodePatchPrompt({ issueText, codeText }) {
+  return [
+    'You are a senior software engineer.',
+    'Given the issue below and the relevant source files, produce a unified diff patch that fixes the issue.',
+    'Requirements:',
+    '- Output only the patch content.',
+    '- Do not wrap the patch in markdown fences.',
+    '- Use standard unified diff format with --- and +++ headers.',
+    '- Do not include explanations before or after the patch.',
+    '',
+    'Issue:',
+    issueText,
+    '',
+    'Source files:',
+    codeText,
+  ].join('\n');
+}
+
+function buildPrompt(mode, { context, diff, tickets, issueText, codeText, patchMode }) {
   if (mode === 'ac') {
     return `You are a senior software engineer. Given the following issue description, write clear Acceptance Criteria in checklist format (use "- [ ] " prefix for each item).\n\nIssue:\n${context}`;
   }
@@ -27,6 +51,9 @@ function buildPrompt(mode, { context, diff, tickets, issueText, codeText }) {
   }
   if (mode === 'team') {
     return `You are an experienced engineering manager. Below are open Redmine tickets assigned to one or more team members. Analyze patterns, recurring blockers, risks, and workload. Provide clear, prioritized recommendations to improve the team's delivery.\n\nTickets:\n${tickets}`;
+  }
+  if (patchMode) {
+    return buildCodePatchPrompt({ issueText, codeText });
   }
   // code
   return `You are a senior software engineer. Given the issue below and the relevant source files, analyze the root cause and suggest specific code changes to resolve the issue. Reference file names where possible.\n\nIssue:\n${issueText}\n\nSource files:\n${codeText}`;
@@ -109,6 +136,14 @@ export async function renderAiPanel(container) {
         <input id="ai-code-dir" type="text" placeholder="/path/to/project/src" />
         <label class="ai-label" style="margin-top:8px">Issue ID</label>
         <input id="ai-issue-id" type="number" placeholder="e.g. 42" min="1" />
+        <label class="ai-code-patch-toggle">
+          <input id="ai-code-patch-mode" type="checkbox" />
+          <span>Save AI output as a patch file in this directory</span>
+        </label>
+        <div id="ai-code-patch-file-row" class="ai-config-row" style="display:none">
+          <label class="ai-label">Patch file</label>
+          <input id="ai-code-patch-file" type="text" value="ai-generated.patch" placeholder="ai-generated.patch" />
+        </div>
         <button class="btn btn-secondary" id="btn-load-code" style="margin-top:8px">Load Code &amp; Issue</button>
         <p id="ai-code-status" class="ai-status" style="display:none"></p>
       </div>
@@ -169,6 +204,9 @@ export async function renderAiPanel(container) {
   // Code
   const codeDirEl    = container.querySelector('#ai-code-dir');
   const issueIdEl    = container.querySelector('#ai-issue-id');
+  const codePatchModeEl = container.querySelector('#ai-code-patch-mode');
+  const codePatchFileRowEl = container.querySelector('#ai-code-patch-file-row');
+  const codePatchFileEl = container.querySelector('#ai-code-patch-file');
   const codeStatusEl = container.querySelector('#ai-code-status');
   const btnLoadCode  = container.querySelector('#btn-load-code');
 
@@ -178,6 +216,11 @@ export async function renderAiPanel(container) {
   let currentIssueText = '';
   let currentCodeText  = '';
   let receivedChars    = 0;
+  let generationStartedAt = 0;
+  let generationTimer = null;
+  let activeBackend = backendEl.value;
+  let hasReceivedFirstToken = false;
+  let pendingPatchTarget = null;
 
   // ── Helpers ───────────────────────────────────────────────────────────────
   function showError(msg)  { errorEl.textContent = msg; errorEl.style.display = ''; }
@@ -192,12 +235,105 @@ export async function renderAiPanel(container) {
   function setGenerating(on) {
     btnGenerate.disabled = on;
     btnCancel.disabled   = !on;
+    btnGenerate.textContent = on ? 'Generating…' : 'Generate';
+    modeEl.disabled = on;
+    backendEl.disabled = on;
+    modelEl.disabled = on;
+    codePatchModeEl.disabled = on;
+    codePatchFileEl.disabled = on;
   }
 
   function showSection(key) {
     Object.entries(sectionEls).forEach(([k, el]) => {
       el.style.display = k === key ? '' : 'none';
     });
+  }
+
+  function isPatchMode() {
+    return modeEl.value === 'code' && codePatchModeEl.checked;
+  }
+
+  function sanitizePatchText(text) {
+    const trimmed = String(text || '').trim();
+    if (!trimmed) return '';
+
+    const fenced = trimmed.match(/^```(?:diff|patch)?\s*\n([\s\S]*?)\n```$/i);
+    return fenced ? fenced[1].trim() : trimmed;
+  }
+
+  function looksLikePatch(text) {
+    const normalized = sanitizePatchText(text);
+    return /(^diff --git\s)|(^---\s)|(^\+\+\+\s)|(^@@\s)/m.test(normalized);
+  }
+
+  function formatElapsed(ms) {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return minutes > 0
+      ? `${minutes}m ${String(seconds).padStart(2, '0')}s`
+      : `${seconds}s`;
+  }
+
+  function clearGenerationTimer() {
+    if (generationTimer) {
+      clearInterval(generationTimer);
+      generationTimer = null;
+    }
+  }
+
+  function setOutputWaiting(message) {
+    outputSection.style.display = '';
+    outputEl.classList.add('ai-output-waiting');
+    outputEl.textContent = message;
+  }
+
+  function clearOutputWaiting() {
+    outputEl.classList.remove('ai-output-waiting');
+  }
+
+  function updateGenerationStatus() {
+    if (!generationStartedAt) return;
+
+    const backendLabel = BACKEND_LABELS[activeBackend] || activeBackend;
+    const elapsed = formatElapsed(Date.now() - generationStartedAt);
+
+    if (!hasReceivedFirstToken) {
+      const slowHint = Date.now() - generationStartedAt >= 12000
+        ? ' First response is taking a while, but this is normal for Claude/Codex.'
+        : '';
+      setStatus(genStatusEl, `Waiting for ${backendLabel}… ${elapsed} elapsed.${slowHint}`, 'pending');
+      return;
+    }
+
+    setStatus(genStatusEl, `Receiving from ${backendLabel}… ${receivedChars} chars in ${elapsed}.`, 'pending');
+  }
+
+  function startGeneration(backend) {
+    activeBackend = backend;
+    receivedChars = 0;
+    hasReceivedFirstToken = false;
+    generationStartedAt = Date.now();
+    setOutputWaiting(`Waiting for ${BACKEND_LABELS[backend] || backend} to produce the first response…`);
+    updateGenerationStatus();
+    clearGenerationTimer();
+    generationTimer = setInterval(() => {
+      if (!document.contains(outputEl)) {
+        clearGenerationTimer();
+        return;
+      }
+      updateGenerationStatus();
+    }, 1000);
+  }
+
+  function stopGeneration(finalMessage, type = '') {
+    const hadVisibleResponse = hasReceivedFirstToken || receivedChars > 0;
+    clearGenerationTimer();
+    generationStartedAt = 0;
+    hasReceivedFirstToken = false;
+    clearOutputWaiting();
+    if (!hadVisibleResponse) outputEl.textContent = '';
+    if (finalMessage) setStatus(genStatusEl, finalMessage, type);
   }
 
   // ── Backend / mode switches ───────────────────────────────────────────────
@@ -207,6 +343,10 @@ export async function renderAiPanel(container) {
 
   modeEl.addEventListener('change', () => {
     showSection(MODES[modeEl.value].section);
+  });
+
+  codePatchModeEl.addEventListener('change', () => {
+    codePatchFileRowEl.style.display = codePatchModeEl.checked ? '' : 'none';
   });
 
   // ── Load git diff ─────────────────────────────────────────────────────────
@@ -354,24 +494,33 @@ export async function renderAiPanel(container) {
       tickets:    currentTickets,
       issueText:  currentIssueText,
       codeText:   currentCodeText,
+      patchMode:  isPatchMode(),
     });
 
-    outputEl.textContent = '';
-    outputSection.style.display = '';
-    receivedChars = 0;
-    setStatus(genStatusEl, 'Starting…', '');
+    pendingPatchTarget = isPatchMode()
+      ? {
+          dir: codeDirEl.value.trim(),
+          filename: codePatchFileEl.value.trim() || 'ai-generated.patch',
+        }
+      : null;
+
     setGenerating(true);
+    startGeneration(backend);
 
     window.redmine.ai.generate(prompt, backend, model);
   });
 
   btnCancel.addEventListener('click', () => {
     window.redmine.ai.cancel();
+    pendingPatchTarget = null;
     setGenerating(false);
-    setStatus(genStatusEl, 'Cancelled.', '');
+    const elapsed = generationStartedAt ? formatElapsed(Date.now() - generationStartedAt) : '0s';
+    stopGeneration(`Cancelled after ${elapsed}.`, '');
   });
 
   btnClear.addEventListener('click', () => {
+    pendingPatchTarget = null;
+    stopGeneration('');
     outputEl.textContent = '';
     outputSection.style.display = 'none';
     hideError();
@@ -388,21 +537,58 @@ export async function renderAiPanel(container) {
   // ── AI streaming ──────────────────────────────────────────────────────────
   window.redmine.on('ai:token', (token) => {
     if (!document.contains(outputEl)) return;
+    if (!hasReceivedFirstToken) {
+      hasReceivedFirstToken = true;
+      outputEl.textContent = '';
+      clearOutputWaiting();
+    }
     receivedChars += token.length;
     outputEl.textContent += token;
     outputEl.scrollTop = outputEl.scrollHeight;
-    setStatus(genStatusEl, `Receiving… (${receivedChars} chars)`, '');
+    updateGenerationStatus();
   });
 
-  window.redmine.on('ai:done', () => {
+  window.redmine.on('ai:done', async () => {
     if (!document.contains(btnGenerate)) return;
     setGenerating(false);
-    setStatus(genStatusEl, `Done — ${receivedChars} chars received.`, 'ok');
+    if (pendingPatchTarget) {
+      const patchText = sanitizePatchText(outputEl.textContent);
+      const elapsed = generationStartedAt ? formatElapsed(Date.now() - generationStartedAt) : '0s';
+
+      if (!looksLikePatch(patchText)) {
+        pendingPatchTarget = null;
+        stopGeneration('');
+        showError('AI did not return a valid unified diff patch, so no patch file was saved.');
+        return;
+      }
+
+      const saveResult = await window.redmine.code.writePatch(
+        pendingPatchTarget.dir,
+        pendingPatchTarget.filename,
+        patchText,
+      );
+      pendingPatchTarget = null;
+
+      if (!saveResult.ok) {
+        stopGeneration('');
+        showError(saveResult.error || 'Failed to save patch file.');
+        return;
+      }
+
+      setStatus(codeStatusEl, `Patch saved to ${saveResult.path}`, 'ok');
+      stopGeneration(`Done — patch saved in ${elapsed}.`, 'ok');
+      return;
+    }
+
+    const elapsed = generationStartedAt ? formatElapsed(Date.now() - generationStartedAt) : '0s';
+    stopGeneration(`Done — ${receivedChars} chars received in ${elapsed}.`, 'ok');
   });
 
   window.redmine.on('ai:error', (err) => {
     if (!document.contains(errorEl)) return;
+    pendingPatchTarget = null;
     setGenerating(false);
+    stopGeneration('');
     genStatusEl.style.display = 'none';
     showError(err);
   });

--- a/src/renderer/js/views/aiPanel.js
+++ b/src/renderer/js/views/aiPanel.js
@@ -119,6 +119,7 @@ export async function renderAiPanel(container) {
         <button class="btn" id="btn-ai-clear">Clear</button>
       </div>
 
+      <p id="ai-gen-status" class="ai-status" style="display:none"></p>
       <p id="ai-error" class="ai-error" style="display:none"></p>
 
       <div id="ai-output-section" class="ai-output-section" style="display:none">
@@ -136,6 +137,7 @@ export async function renderAiPanel(container) {
   const modelEl        = container.querySelector('#ai-model');
   const outputSection  = container.querySelector('#ai-output-section');
   const outputEl       = container.querySelector('#ai-output');
+  const genStatusEl    = container.querySelector('#ai-gen-status');
   const errorEl        = container.querySelector('#ai-error');
   const btnGenerate    = container.querySelector('#btn-ai-generate');
   const btnCancel      = container.querySelector('#btn-ai-cancel');
@@ -175,6 +177,7 @@ export async function renderAiPanel(container) {
   let currentTickets = '';
   let currentIssueText = '';
   let currentCodeText  = '';
+  let receivedChars    = 0;
 
   // ── Helpers ───────────────────────────────────────────────────────────────
   function showError(msg)  { errorEl.textContent = msg; errorEl.style.display = ''; }
@@ -355,6 +358,8 @@ export async function renderAiPanel(container) {
 
     outputEl.textContent = '';
     outputSection.style.display = '';
+    receivedChars = 0;
+    setStatus(genStatusEl, 'Starting…', '');
     setGenerating(true);
 
     window.redmine.ai.generate(prompt, backend, model);
@@ -363,6 +368,7 @@ export async function renderAiPanel(container) {
   btnCancel.addEventListener('click', () => {
     window.redmine.ai.cancel();
     setGenerating(false);
+    setStatus(genStatusEl, 'Cancelled.', '');
   });
 
   btnClear.addEventListener('click', () => {
@@ -370,6 +376,7 @@ export async function renderAiPanel(container) {
     outputSection.style.display = 'none';
     hideError();
     setGenerating(false);
+    genStatusEl.style.display = 'none';
   });
 
   btnCopy.addEventListener('click', () => {
@@ -381,18 +388,22 @@ export async function renderAiPanel(container) {
   // ── AI streaming ──────────────────────────────────────────────────────────
   window.redmine.on('ai:token', (token) => {
     if (!document.contains(outputEl)) return;
+    receivedChars += token.length;
     outputEl.textContent += token;
     outputEl.scrollTop = outputEl.scrollHeight;
+    setStatus(genStatusEl, `Receiving… (${receivedChars} chars)`, '');
   });
 
   window.redmine.on('ai:done', () => {
     if (!document.contains(btnGenerate)) return;
     setGenerating(false);
+    setStatus(genStatusEl, `Done — ${receivedChars} chars received.`, 'ok');
   });
 
   window.redmine.on('ai:error', (err) => {
     if (!document.contains(errorEl)) return;
     setGenerating(false);
+    genStatusEl.style.display = 'none';
     showError(err);
   });
 

--- a/src/renderer/js/views/aiPanel.js
+++ b/src/renderer/js/views/aiPanel.js
@@ -36,6 +36,14 @@ export async function renderAiPanel(container) {
           </select>
         </div>
         <div class="ai-config-row">
+          <label class="ai-label">Backend</label>
+          <select id="ai-backend">
+            <option value="ollama">Ollama (local)</option>
+            <option value="claude">Claude CLI</option>
+            <option value="codex">Codex CLI</option>
+          </select>
+        </div>
+        <div class="ai-config-row" id="ai-model-row">
           <label class="ai-label">Model</label>
           <input id="ai-model" type="text" value="llama3.2" placeholder="e.g. llama3.2, codellama" />
         </div>
@@ -73,6 +81,8 @@ export async function renderAiPanel(container) {
   `;
 
   const modeEl         = container.querySelector('#ai-mode');
+  const backendEl      = container.querySelector('#ai-backend');
+  const modelRowEl     = container.querySelector('#ai-model-row');
   const modelEl        = container.querySelector('#ai-model');
   const contextSection = container.querySelector('#ai-context-section');
   const contextEl      = container.querySelector('#ai-context');
@@ -104,6 +114,11 @@ export async function renderAiPanel(container) {
     btnGenerate.disabled = on;
     btnCancel.disabled   = !on;
   }
+
+  // Backend switch — hide model input for Claude/Codex (no model needed)
+  backendEl.addEventListener('change', () => {
+    modelRowEl.style.display = backendEl.value === 'ollama' ? '' : 'none';
+  });
 
   // Mode switch
   modeEl.addEventListener('change', () => {
@@ -140,8 +155,9 @@ export async function renderAiPanel(container) {
   // Generate
   btnGenerate.addEventListener('click', () => {
     hideError();
-    const mode  = modeEl.value;
-    const model = modelEl.value.trim() || 'llama3.2';
+    const mode    = modeEl.value;
+    const backend = backendEl.value;
+    const model   = modelEl.value.trim() || 'llama3.2';
 
     if (MODES[mode].needsDiff) {
       if (!currentDiff) { showError('Load a git diff first.'); return; }
@@ -155,7 +171,7 @@ export async function renderAiPanel(container) {
     outputSection.style.display = '';
     setGenerating(true);
 
-    window.redmine.ai.generate(prompt, model);
+    window.redmine.ai.generate(prompt, backend, model);
   });
 
   // Cancel

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -7,6 +7,7 @@ const IPC = {
 
   // Projects
   PROJECT_MEMBERS: 'project:members',
+  PROJECTS_LIST: 'projects:list',
 
   // Issues
   ISSUES_FETCH: 'issues:fetch',
@@ -15,6 +16,10 @@ const IPC = {
   ISSUES_UPDATE: 'issues:update',
   ISSUES_FETCH_CHILDREN: 'issues:fetchChildren',
   ISSUES_STATUSES: 'issues:statuses',
+  ISSUES_FETCH_BY_ASSIGNEES: 'issues:fetchByAssignees',
+
+  // Code
+  CODE_READ: 'code:read',
 
   // Time
   TIME_LOG: 'time:log',

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -20,6 +20,7 @@ const IPC = {
 
   // Code
   CODE_READ: 'code:read',
+  CODE_WRITE_PATCH: 'code:writePatch',
 
   // Time
   TIME_LOG: 'time:log',


### PR DESCRIPTION
## Summary

- **`src/main/api/aiClient.js`** — Spawns `ollama run <model>`, probes `/usr/local/bin/ollama` and `/opt/homebrew/bin/ollama` before PATH fallback, streams stdout tokens via callbacks, surfaces clear "Ollama not found" error on `ENOENT`
- **`src/main/ipc/ai.ipc.js`** — `ipcMain.on(AI_GENERATE)` starts ollama and relays `AI_TOKEN` / `AI_DONE` / `AI_ERROR` to renderer in real time; `AI_CANCEL` kills the active process
- **`src/main/ipc/git.ipc.js`** — `ipcMain.handle(GIT_DIFF)` runs `git diff HEAD` in the user-supplied repo path, returns `{ ok, diff }` or `{ ok: false, error }`
- **`src/renderer/js/views/aiPanel.js`** — Chat-like AI panel with three modes: Generate Acceptance Criteria, Generate Sub-tasks, Summarize Git Diff; streaming output with Cancel and Copy buttons
- **`src/renderer/index.html` + `app.js`** — AI nav tab added and wired
- **`src/renderer/css/ai.css`** — AI panel styles

## Test plan

- [ ] With Ollama installed and a model pulled: open AI tab → select a mode → enter context → Generate → tokens stream in real time
- [ ] Cancel button kills the stream mid-generation
- [ ] Git Diff mode: enter a valid repo path → Load Diff → diff preview appears → Generate produces a journal-style summary
- [ ] With Ollama not installed: clicking Generate shows "Ollama not found" error, all other app features work normally
- [ ] Invalid repo path in Git Diff mode shows an error message

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)